### PR TITLE
Filter out projects with invalid project names

### DIFF
--- a/src/dataLoaders/ProjectsDataSource.ts
+++ b/src/dataLoaders/ProjectsDataSource.ts
@@ -5,6 +5,7 @@ import ProjectModel from '../project/ProjectModel';
 import type { FakeUnclaimedProject, ProjectId } from '../common/types';
 import {
   doesRepoExists,
+  isValidateProjectName,
   toApiProject,
   toFakeUnclaimedProjectFromUrl,
 } from '../project/projectUtils';
@@ -20,7 +21,11 @@ export default class ProjectsDataSource {
           },
           isValid: true,
         },
-      });
+      }).then((projectModels) =>
+        projectModels.filter((p) =>
+          p.name ? isValidateProjectName(p.name) : true,
+        ),
+      );
 
       const projectIdToProjectMap = projects.reduce<
         Record<ProjectId, ProjectModel>
@@ -64,6 +69,7 @@ export default class ProjectsDataSource {
 
     return projects
       .filter((p) => p.isValid)
+      .filter((p) => (p.name ? isValidateProjectName(p.name) : true))
       .map(toApiProject)
       .filter(Boolean) as (ProjectModel | FakeUnclaimedProject)[];
   }

--- a/src/project/projectUtils.ts
+++ b/src/project/projectUtils.ts
@@ -1,22 +1,12 @@
-import { Op } from 'sequelize';
 import { ethers } from 'ethers';
 import type { FakeUnclaimedProject, Forge, ProjectId } from '../common/types';
 import shouldNeverHappen from '../utils/shouldNeverHappen';
-import ProjectModel, { ProjectVerificationStatus } from './ProjectModel';
+import type ProjectModel from './ProjectModel';
+import { ProjectVerificationStatus } from './ProjectModel';
 import { RepoDriver__factory } from '../generated/contracts';
 import assert from '../utils/assert';
 import appSettings from '../common/appSettings';
 import provider from '../common/provider';
-
-export async function getProjects(ids: ProjectId[]): Promise<ProjectModel[]> {
-  return ProjectModel.findAll({
-    where: {
-      id: {
-        [Op.in]: ids,
-      },
-    },
-  });
-}
 
 export function splitProjectName(projectName: string): {
   ownerName: string;
@@ -29,6 +19,28 @@ export function splitProjectName(projectName: string): {
   }
 
   return { ownerName: components[0], repoName: components[1] };
+}
+
+export function isValidateProjectName(name: string): boolean {
+  const components = name.split('/');
+
+  if (components.length !== 2) {
+    return false;
+  }
+
+  const ownerName = components[0];
+  const repoName = components[1];
+
+  const validProjectNameRegex: RegExp = /^[\w.-]+$/;
+
+  if (
+    !validProjectNameRegex.test(ownerName) ||
+    !validProjectNameRegex.test(repoName)
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 function toContractForge(forge: Forge): 0 | 1 {


### PR DESCRIPTION
Projects with invalid project names results in the whole query to fail. These changes will fix failing queries on production. Later, we will introduce a check while processing the relevant events in the events processor as well.