### PR TITLE
refactor: pass queried chains to account ID calculation logic

### DIFF
--- a/src/common/dripsContracts.ts
+++ b/src/common/dripsContracts.ts
@@ -12,11 +12,12 @@ import type {
   AccountId,
   Address,
   AddressDriverId,
+  DbSchema,
   Forge,
   ProjectId,
 } from './types';
-import queryableChains from './queryableChains';
 import FailoverJsonRpcProvider from './FailoverProvider';
+import { dbSchemaToChain } from '../utils/chainSchemaMappings';
 
 const chainConfigs: Record<
   SupportedChain,
@@ -132,17 +133,20 @@ export default dripsContracts;
 
 export async function getCrossChainAddressDriverAccountIdByAddress(
   address: Address,
+  chainsToQuery: DbSchema[],
 ): Promise<AddressDriverId> {
   // AddressDriver account IDs are the same across all chains.
-  const availableChain = queryableChains.find(
-    (chain) => dripsContracts[chain] && dripsContracts[chain]!.addressDriver,
+  const availableChain = chainsToQuery.find(
+    (chain) =>
+      dripsContracts[dbSchemaToChain[chain]] &&
+      dripsContracts[dbSchemaToChain[chain]]!.addressDriver,
   );
 
   if (!availableChain) {
     throw new Error('No available chain with initialized contracts.');
   }
 
-  const { addressDriver } = dripsContracts[availableChain]!;
+  const { addressDriver } = dripsContracts[dbSchemaToChain[availableChain]]!;
 
   const accountId = (await addressDriver.calcAccountId(address)).toString();
 
@@ -152,17 +156,20 @@ export async function getCrossChainAddressDriverAccountIdByAddress(
 export async function getCrossChainRepoDriverAccountIdByAddress(
   forge: Forge,
   project: string,
+  chainsToQuery: DbSchema[],
 ): Promise<AccountId> {
   // RepoDriver account IDs are the same across all chains.
-  const availableChain = queryableChains.find(
-    (chain) => dripsContracts[chain] && dripsContracts[chain]!.repoDriver,
+  const availableChain = chainsToQuery.find(
+    (chain) =>
+      dripsContracts[dbSchemaToChain[chain]] &&
+      dripsContracts[dbSchemaToChain[chain]]!.repoDriver,
   );
 
   if (!availableChain) {
     throw new Error('No available chain with initialized contracts.');
   }
 
-  const { repoDriver } = dripsContracts[availableChain]!;
+  const { repoDriver } = dripsContracts[dbSchemaToChain[availableChain]]!;
 
   const nameAsBytesLike = ethers.toUtf8Bytes(project);
 

--- a/src/dataLoaders/ProjectsDataSource.ts
+++ b/src/dataLoaders/ProjectsDataSource.ts
@@ -36,7 +36,7 @@ export default class ProjectsDataSource {
       );
 
       const apiProjectsDataValues = await Promise.all(
-        projectsDataValues.map(toApiProject),
+        projectsDataValues.map((p) => toApiProject(p, chains)),
       );
 
       const filteredProjectsDataValues = apiProjectsDataValues.filter(
@@ -101,7 +101,7 @@ export default class ProjectsDataSource {
     const dbProjects = await projectsQueries.getByUrl(chains, url);
 
     if (!dbProjects?.length) {
-      return [await toProjectRepresentationFromUrl(url)];
+      return [await toProjectRepresentationFromUrl(url, chains)];
     }
 
     if (dbProjects.some((p) => p.id !== dbProjects[0].id)) {
@@ -126,7 +126,7 @@ export default class ProjectsDataSource {
 
     return Promise.all(
       projectsDataValues
-        .map(toApiProject)
+        .map((p) => toApiProject(p, chains))
         .filter(Boolean) as ProjectDataValues[],
     );
   }

--- a/src/user/userResolvers.ts
+++ b/src/user/userResolvers.ts
@@ -73,8 +73,10 @@ const userResolvers = {
         (chain) => chainToDbSchema[chain],
       );
 
-      const accountId =
-        await getCrossChainAddressDriverAccountIdByAddress(address);
+      const accountId = await getCrossChainAddressDriverAccountIdByAddress(
+        address,
+        dbSchemasToQuery,
+      );
 
       return toResolverUser(dbSchemasToQuery, accountId);
     },


### PR DESCRIPTION
This PR addresses the issue of a network-specific app deployment calling a provider from a different network (e.g., `mainnet` app failed because `filecoin` provider was down).

The bug was as follows: due to account IDs being the same across different chains, the existing logic was somehow randomly selecting any chain from all _queryable_ chains to create contract clients and execute the logic. These queryable chains are defined in the `RPC_CONFIG`. As a result, a deployment on the `mainnet` could request an account ID from a `filecoin` contract instance (as long as it listed in the env var). Additionally, there was some more randomness involved, as the array of queryable chains was constructed based on the order of arbitrary JSON contract data.

What has changed now is that the chain selection happens only on the chains indicated in the query. If no chain is specified in the query, the API will still search through all queryable chains, as this suggests that the caller wants results from every available chain, but this shouldn't cause any issues.