### PR TITLE
refactor: throw meaningful error when GH URL is invalid

### DIFF
--- a/src/project/projectResolvers.ts
+++ b/src/project/projectResolvers.ts
@@ -1,3 +1,4 @@
+import { GraphQLError } from 'graphql';
 import type {
   NftDriverId,
   RepoDriverId,
@@ -104,7 +105,9 @@ const projectResolvers = {
       { dataSources: { projectsDataSource } }: Context,
     ): Promise<ResolverProject | null> => {
       if (!isGitHubUrl(url)) {
-        return null;
+        throw new GraphQLError('Only valid GitHub URLs are supported.', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
       }
 
       if (chains?.length) {


### PR DESCRIPTION
This was already fixed and returned `null`.
Made it to throw a meaningful error in case we prefer this approach. No need to approve if we prefer `null`.