### PR TITLE
fix(database): cast ENUM columns to text in cross-schema UNION queries

### DIFF
--- a/src/dataLoaders/sqlQueries/linkedIdentityQueries.ts
+++ b/src/dataLoaders/sqlQueries/linkedIdentityQueries.ts
@@ -13,8 +13,19 @@ export default {
     chains: DbSchema[],
     accountIds: RepoDriverId[],
   ): Promise<LinkedIdentityDataValues[]> {
-    const baseSQL = (schema: DbSchema) =>
-      `SELECT *, '${schema}' AS chain FROM ${schema}.linked_identities`;
+    const baseSQL = (schema: DbSchema) => `
+      SELECT
+        account_id,
+        identity_type::text as identity_type,
+        owner_address,
+        owner_account_id,
+        is_linked,
+        last_processed_version,
+        created_at,
+        updated_at,
+        '${schema}' AS chain
+      FROM ${schema}.linked_identities
+    `;
 
     const parameters: { [key: string]: any } = { accountIds };
 
@@ -38,8 +49,19 @@ export default {
     chains: DbSchema[],
     ownerAddress: Address,
   ): Promise<LinkedIdentityDataValues[]> {
-    const baseSQL = (schema: DbSchema) =>
-      `SELECT *, '${schema}' AS chain FROM ${schema}.linked_identities`;
+    const baseSQL = (schema: DbSchema) => `
+      SELECT
+        account_id,
+        identity_type::text as identity_type,
+        owner_address,
+        owner_account_id,
+        is_linked,
+        last_processed_version,
+        created_at,
+        updated_at,
+        '${schema}' AS chain
+      FROM ${schema}.linked_identities
+    `;
 
     const parameters: { [key: string]: any } = { ownerAddress };
 
@@ -65,8 +87,19 @@ export default {
     sort?: OrcidAccountSortInput,
     limit: number = 100,
   ): Promise<LinkedIdentityDataValues[]> {
-    const baseSQL = (schema: DbSchema) =>
-      `SELECT *, '${schema}' AS chain FROM ${schema}.linked_identities`;
+    const baseSQL = (schema: DbSchema) => `
+      SELECT
+        account_id,
+        identity_type::text as identity_type,
+        owner_address,
+        owner_account_id,
+        is_linked,
+        last_processed_version,
+        created_at,
+        updated_at,
+        '${schema}' AS chain
+      FROM ${schema}.linked_identities
+    `;
 
     const parameters: { [key: string]: any } = { limit };
     let whereClause = ` WHERE "identity_type" = 'orcid'`;
@@ -108,8 +141,19 @@ export default {
     accountId: RepoDriverId,
     chains: DbSchema[],
   ): Promise<LinkedIdentityDataValues[] | null> {
-    const baseSQL = (schema: DbSchema) =>
-      `SELECT *, '${schema}' AS chain FROM ${schema}.linked_identities`;
+    const baseSQL = (schema: DbSchema) => `
+      SELECT
+        account_id,
+        identity_type::text as identity_type,
+        owner_address,
+        owner_account_id,
+        is_linked,
+        last_processed_version,
+        created_at,
+        updated_at,
+        '${schema}' AS chain
+      FROM ${schema}.linked_identities
+    `;
 
     const parameters: { [key: string]: any } = { accountId };
     const whereClause = ` WHERE "account_id" = :accountId AND "identity_type" = 'orcid'`;

--- a/src/dataLoaders/sqlQueries/projectsQueries.ts
+++ b/src/dataLoaders/sqlQueries/projectsQueries.ts
@@ -17,7 +17,26 @@ async function getProjectByUrl(
   url: string,
 ): Promise<ProjectDataValues[]> {
   const baseSQL = (schema: DbSchema) => `
-    SELECT *, '${schema}' AS chain FROM ${schema}.projects
+    SELECT
+      account_id,
+      is_valid,
+      is_visible,
+      name,
+      verification_status::text as verification_status,
+      owner_address,
+      owner_account_id,
+      forge::text as forge,
+      url,
+      emoji,
+      avatar_cid,
+      color,
+      last_processed_ipfs_hash,
+      last_processed_version,
+      claimed_at,
+      created_at,
+      updated_at,
+      '${schema}' AS chain
+    FROM ${schema}.projects
   `;
 
   const conditions: string[] = ['url = :url', 'is_valid = true'];
@@ -45,8 +64,28 @@ async function getProjectsByFilter(
   sort?: ProjectSortInput,
   limit?: number,
 ): Promise<ProjectDataValues[]> {
-  const baseSQL = (schema: DbSchema) =>
-    `SELECT *, '${schema}' AS chain FROM ${schema}.projects `;
+  const baseSQL = (schema: DbSchema) => `
+    SELECT
+      account_id,
+      is_valid,
+      is_visible,
+      name,
+      verification_status::text as verification_status,
+      owner_address,
+      owner_account_id,
+      forge::text as forge,
+      url,
+      emoji,
+      avatar_cid,
+      color,
+      last_processed_ipfs_hash,
+      last_processed_version,
+      claimed_at,
+      created_at,
+      updated_at,
+      '${schema}' AS chain
+    FROM ${schema}.projects
+  `;
 
   const conditions: string[] = ['is_valid = true'];
   const parameters: { [key: string]: any } = {};
@@ -95,8 +134,28 @@ async function getProjectsByIds(
   chains: DbSchema[],
   projectIds: RepoDriverId[],
 ): Promise<ProjectDataValues[]> {
-  const baseSQL = (schema: DbSchema) =>
-    `SELECT *, '${schema}' AS chain FROM ${schema}.projects`;
+  const baseSQL = (schema: DbSchema) => `
+    SELECT
+      account_id,
+      is_valid,
+      is_visible,
+      name,
+      verification_status::text as verification_status,
+      owner_address,
+      owner_account_id,
+      forge::text as forge,
+      url,
+      emoji,
+      avatar_cid,
+      color,
+      last_processed_ipfs_hash,
+      last_processed_version,
+      claimed_at,
+      created_at,
+      updated_at,
+      '${schema}' AS chain
+    FROM ${schema}.projects
+  `;
 
   const parameters: { [key: string]: any } = { projectIds };
 

--- a/src/dataLoaders/sqlQueries/splitsReceiversQueries.ts
+++ b/src/dataLoaders/sqlQueries/splitsReceiversQueries.ts
@@ -8,8 +8,22 @@ export async function getSplitsReceivers(
   chains: DbSchema[],
   receiverAccountIds: AccountId[],
 ) {
-  const baseSQL = (schema: DbSchema) =>
-    `SELECT *, '${schema}' AS chain FROM ${schema}.splits_receivers`;
+  const baseSQL = (schema: DbSchema) => `
+    SELECT
+      id,
+      receiver_account_id,
+      receiver_account_type::text as receiver_account_type,
+      sender_account_id,
+      sender_account_type::text as sender_account_type,
+      relationship_type::text as relationship_type,
+      weight,
+      block_timestamp,
+      splits_to_repo_driver_sub_account,
+      created_at,
+      updated_at,
+      '${schema}' AS chain
+    FROM ${schema}.splits_receivers
+  `;
 
   const conditions: string[] = ['receiver_account_id IN (:receiverAccountIds)'];
 
@@ -37,8 +51,22 @@ export async function getSplitsReceiversForSenderIds(
   chains: DbSchema[],
   senderAccountIds: AccountId[],
 ) {
-  const baseSQL = (schema: DbSchema) =>
-    `SELECT *, '${schema}' AS chain FROM ${schema}.splits_receivers`;
+  const baseSQL = (schema: DbSchema) => `
+    SELECT
+      id,
+      receiver_account_id,
+      receiver_account_type::text as receiver_account_type,
+      sender_account_id,
+      sender_account_type::text as sender_account_type,
+      relationship_type::text as relationship_type,
+      weight,
+      block_timestamp,
+      splits_to_repo_driver_sub_account,
+      created_at,
+      updated_at,
+      '${schema}' AS chain
+    FROM ${schema}.splits_receivers
+  `;
 
   const conditions: string[] = ['sender_account_id IN (:senderAccountIds)'];
 


### PR DESCRIPTION
Explicitly querying the columns was the past implementation and a newer commit broke it. We could simplify this with a CTE or subquery, but given the timing, this is the quickest working solution.